### PR TITLE
修正了共享页面的pivot

### DIFF
--- a/src/llamacpp.py
+++ b/src/llamacpp.py
@@ -52,16 +52,24 @@ def _llamacpp(filename: str):
     )
 
 
+LLAMACPP_DOWNLOAD_SRC = [
+    "GitHub",
+    "GHProxy",
+]
+
 LLAMACPP_LIST: List[Llamacpp] = [
     _llamacpp("llama-b3923-bin-win-cuda-cu12.2.0-x64.zip"),
     _llamacpp("llama-b3384-bin-win-rocm-avx2-x64.zip"),
     _llamacpp("llama-b3534-bin-win-rocm-avx512-x64.zip"),
     _llamacpp("llama-b3923-bin-win-vulkan-x64.zip"),
 ]
-LLAMACPP_CUDART_FILENAME = "cudart-llama-bin-win-cu12.2.0-x64.zip"
-LLAMACPP_CUDART_DOWNLOAD_LINK = {
-    "GitHub": "https://github.com/ggerganov/llama.cpp/releases/download/b3926/cudart-llama-bin-win-cu12.2.0-x64.zip",
-    "GHProxy": "https://ghp.ci/https://github.com/ggerganov/llama.cpp/releases/download/b3926/cudart-llama-bin-win-cu12.2.0-x64.zip",
+
+LLAMACPP_CUDART = {
+    "filename": "cudart-llama-bin-win-cu12.2.0-x64.zip",
+    "download_links": {
+        "GitHub": "https://github.com/ggerganov/llama.cpp/releases/download/b3926/cudart-llama-bin-win-cu12.2.0-x64.zip",
+        "GHProxy": "https://ghp.ci/https://github.com/ggerganov/llama.cpp/releases/download/b3926/cudart-llama-bin-win-cu12.2.0-x64.zip",
+    },
 }
 
 

--- a/src/sakura.py
+++ b/src/sakura.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import Dict
+from hashlib import sha256
+
+
+@dataclass
+class Sakura:
+    repo: str
+    filename: str
+    sha256: str
+    size: float
+    download_links: Dict[str, str]
+
+    def check_sha256(self, file: str):
+        sha256_hash = sha256()
+        with open(file, "rb") as f:
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha256_hash.update(byte_block)
+        return sha256_hash.hexdigest() == self.sha256
+
+
+def _sakura(repo, filename, sha256, size):
+    return Sakura(
+        repo=repo,
+        filename=filename,
+        sha256=sha256,
+        size=size,
+        download_links={
+            "HFMirror": f"https://hf-mirror.com/SakuraLLM/{repo}/resolve/main/{filename}",
+            "HuggingFace": f"https://huggingface.co/SakuraLLM/{repo}/resolve/main/{filename}",
+        },
+    )
+
+
+SAKURA_DOWNLOAD_SRC = [
+    "HFMirror",
+    "HuggingFace",
+]
+
+SAKURA_LIST = [
+    _sakura(
+        repo="GalTransl-7B-v2",
+        filename="GalTransl-7B-v2-IQ4_XS.gguf",
+        sha256="8749e704993a2c327f319278818ba0a7f9633eae8ed187d54eb63456a11812aa",
+        size=4.29,
+    ),
+    _sakura(
+        repo="SakuraLLM/Sakura-14B-Qwen2.5-v1.0-GGUF",
+        filename="sakura-14b-qwen2.5-v1.0-iq4xs.gguf",
+        sha256="34af88f99c113418d0665d3ceede767c9a12040c9e7c4bb5e87cdb1b1e06e94a",
+        size=8.19,
+    ),
+    _sakura(
+        repo="SakuraLLM/Sakura-14B-Qwen2.5-v1.0-GGUF",
+        filename="sakura-14b-qwen2.5-v1.0-q4km.gguf",
+        sha256="c87697cd9c7898464426cb7a1ec5e220755affaa08096766e8d20de1853c2063",
+        size=8.99,
+    ),
+    _sakura(
+        repo="Sakura-14B-Qwen2beta-v0.9.2-GGUF",
+        filename="sakura-14b-qwen2beta-v0.9.2-iq4xs.gguf",
+        sha256="254a7e97e5e2a5daa371145e55bb2b0a0a789615dab2d4316189ba089a3ced67",
+        size=7.91,
+    ),
+    _sakura(
+        repo="Sakura-14B-Qwen2beta-v0.9.2-GGUF",
+        filename="sakura-14b-qwen2beta-v0.9.2-q4km.gguf",
+        sha256="8bae1ae35b7327fa7c3a8f3ae495b81a071847d560837de2025e1554364001a5",
+        size=9.19,
+    ),
+]

--- a/src/section_share.py
+++ b/src/section_share.py
@@ -3,7 +3,6 @@ import json
 import subprocess
 import requests
 import re
-import time
 from PySide6.QtCore import (
     Qt,
     Signal,
@@ -17,9 +16,7 @@ from PySide6.QtCore import (
 )
 from PySide6.QtWidgets import (
     QVBoxLayout,
-    QHBoxLayout,
     QLabel,
-    QGroupBox,
     QSpacerItem,
     QSizePolicy,
     QTableWidgetItem,
@@ -201,11 +198,9 @@ class CFShareSection(QFrame):
         self.worker = None
 
     def _init_ui(self):
-        layout = QVBoxLayout()
-
         # 创建标签页切换控件
-        self.pivot = SegmentedWidget()
-        self.stacked_widget = QStackedWidget()
+        pivot = SegmentedWidget()
+        stacked_widget = QStackedWidget()
 
         # 创建不同的页面
         self.share_page = QWidget()
@@ -216,22 +211,26 @@ class CFShareSection(QFrame):
         self.init_metrics_page()
         self.init_ranking_page()
 
-        self.add_sub_interface(self.share_page, "share_page", "共享设置")
-        self.add_sub_interface(self.metrics_page, "metrics_page", "本地数据统计")
-        self.add_sub_interface(self.ranking_page, "ranking_page", "在线排名")
+        def add_sub_interface(widget: QWidget, object_name, text):
+            widget.setObjectName(object_name)
+            stacked_widget.addWidget(widget)
+            pivot.addItem(
+                routeKey=object_name,
+                text=text,
+                onClick=lambda: stacked_widget.setCurrentWidget(widget),
+            )
 
-        layout.addWidget(self.pivot)
-        layout.addWidget(self.stacked_widget)
+        add_sub_interface(self.share_page, "share_page", "共享设置")
+        add_sub_interface(self.metrics_page, "metrics_page", "本地数据统计")
+        add_sub_interface(self.ranking_page, "ranking_page", "在线排名")
 
-        self.setLayout(layout)
+        pivot.setCurrentItem(stacked_widget.currentWidget().objectName())
 
-    def add_sub_interface(self, widget: QWidget, object_name, text):
-        widget.setObjectName(object_name)
-        self.stacked_widget.addWidget(widget)
-        self.pivot.addItem(
-            routeKey=object_name,
-            text=text,
-            onClick=lambda: self.stacked_widget.setCurrentWidget(widget),
+        self.setLayout(
+            UiCol(
+                pivot,
+                stacked_widget,
+            )
         )
 
     def init_share_page(self):

--- a/src/ui.py
+++ b/src/ui.py
@@ -3,6 +3,7 @@ from PySide6.QtCore import Qt, QTimer, QSize
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QFrame, QLayout
 from qfluentwidgets import (
     CheckBox,
+    ComboBox,
     FluentStyleSheet,
     LineEdit,
     Slider,
@@ -140,9 +141,16 @@ def UiSlider(
 
 
 def UiEditableComboBox(items):
-    combo_box = EditableComboBox()
-    combo_box.addItems(items)
-    return combo_box
+    w = EditableComboBox()
+    w.addItems(items)
+    return w
+
+
+def UiComboBox(items, on_change):
+    w = ComboBox()
+    w.addItems(items)
+    w.currentTextChanged.connect(on_change)
+    return w
 
 
 Child = QWidget | QLayout | None


### PR DESCRIPTION
- 修正了共享页面的pivot
- 下载标签页面显示Sakura模型大小，并支持切换下载源

因为动了共享页面的代码，所以又提了个pr。