### PR TITLE
删除 SakuraShareAPI 的多余参数

### DIFF
--- a/src/sakura_share_cli.py
+++ b/src/sakura_share_cli.py
@@ -58,9 +58,7 @@ async def start_sharing(api: SakuraShareAPI, tg_token: str):
                 try:
                     await asyncio.wait_for(stop_event.wait(), timeout=600)
                 except asyncio.TimeoutError:
-                    if not await api.register_node(tg_token):
-                        print("重新连接失败，停止分享")
-                        break
+                    pass
         else:
             print("启动失败，请检查配置和网络连接")
     except Exception as e:

--- a/src/sakura_share_cli.py
+++ b/src/sakura_share_cli.py
@@ -20,7 +20,7 @@ async def main():
 
     args = parser.parse_args()
 
-    api = SakuraShareAPI(args.port, args.worker_url, args.mode)
+    api = SakuraShareAPI(args.port, args.worker_url)
 
     if args.action == "start":
         await start_sharing(api, args.tg_token)


### PR DESCRIPTION
修复 `sakura_share_cli.py` 的一些问题：

- 删除 SakuraShareAPI 的多余参数。
- 删除 register_node 函数的调用，WebSocket 模式本身也不需要该函数。