### PR TITLE
修复llama-cpp更新到b6325版本后`-fa`参数错误问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -329,6 +329,8 @@ class MainWindow(MSFluentWindow):
 
         if section.flash_attention_check.isChecked():
             option_extra.append("-fa")
+            if version >= 6325:     # https://github.com/ggml-org/llama.cpp/releases/tag/b6325
+                option_extra.append("on")
         if section.no_mmap_check.isChecked():
             option_extra.append("--no-mmap")
 


### PR DESCRIPTION
参考 [llama.cpp b6325](https://github.com/ggml-org/llama.cpp/releases/tag/b6325)、[llama.cpp PR#15434](https://github.com/ggml-org/llama.cpp/pull/15434)，`-fa`命令行参数现在需要传值`-fa on`

