### PR TITLE
[WIP] 支持自定义sakura模型下载路径

### DIFF
--- a/src/section_download.py
+++ b/src/section_download.py
@@ -232,7 +232,8 @@ class DownloadSection(QFrame):
 
         description = UiDescription(
             """
-        <p>您可以在这里下载不同版本的模型，模型会保存到启动器所在的目录。如果启动器无法下载，您也可以手动从<a href="https://huggingface.co/SakuraLLM/">Hugging Face镜像站</a>下载模型，将下载的gguf文件放到启动器所在文件夹下即可。</p>
+        <p>您可以在这里下载不同版本的模型，模型会保存到Sakura模型文件夹。如果启动器无法下载，您也可以手动从<a href="https://huggingface.co/SakuraLLM/">Hugging Face镜像站</a>下载模型，将下载的gguf文件放到Sakura模型文件夹下即可。</p>
+        <p>Sakura模型文件夹可以前往设置选项卡修改，默认文件夹为启动器所在的文件夹。</p>
         <p>翻译Galgame推荐使用7B模型，12G以下显存可用。翻译小说推荐使用14B模型，需要12G及以上显存。</p>
         """
         )

--- a/src/section_download.py
+++ b/src/section_download.py
@@ -24,6 +24,7 @@ from .common import CURRENT_DIR, get_resource_path, GHPROXY_URL
 from .llamacpp import *
 from .sakura import SAKURA_LIST, Sakura
 from .ui import *
+from src.setting import *
 
 
 def UiDescription(html):
@@ -99,6 +100,7 @@ class DownloadTask:
     name: str
     url: str
     filename: str
+    filepath: str = None
     state: DownloadTaskState = DownloadTaskState.RUNNING
 
 
@@ -107,10 +109,11 @@ class DownloadThread(QThread):
     sig_success = Signal()
     sig_error = Signal(str)
 
-    def __init__(self, url, filename):
+    def __init__(self, url, filename, filepath = None):
         super().__init__()
         self.url = url
         self.filename = filename
+        self.filepath = filepath
         self._is_finished = False
 
     def run(self):
@@ -123,7 +126,7 @@ class DownloadThread(QThread):
             block_size = 1024  # 1 KB
             downloaded_size = 0
 
-            file_path = os.path.join(CURRENT_DIR, self.filename)
+            file_path = os.path.join(self.filepath if self.filepath else CURRENT_DIR, self.filename)
             with open(file_path, "wb") as file:
                 for data in response.iter_content(block_size):
                     size = file.write(data)
@@ -335,7 +338,7 @@ class DownloadSection(QFrame):
             QApplication.processEvents()  # 确保UI更新
             UiInfoBarError(self, f"{new_task.name}下载失败", content=f"{error_message}")
 
-        thread = DownloadThread(new_task.url, new_task.filename)
+        thread = DownloadThread(new_task.url, new_task.filename, new_task.filepath)
         thread.sig_progress.connect(progress_bar.setValue)
         thread.sig_success.connect(on_finish)
         thread.sig_error.connect(on_error)
@@ -343,7 +346,8 @@ class DownloadSection(QFrame):
 
         self.download_threads.append(thread)
 
-        logging.info(f"开始下载: URL={new_task.url}, 文件名={new_task.filename}")
+        file_path = os.path.join(new_task.filepath if new_task.filepath else CURRENT_DIR, new_task.filename)
+        logging.info(f"开始下载: URL={new_task.url}, 文件路径={file_path}")
         UiInfoBarSuccess(self, f"{new_task.name}开始下载，请在下载进度页面查看进度")
 
     def _update_current_llamacpp_version(self):
@@ -355,14 +359,18 @@ class DownloadSection(QFrame):
 
     def start_download_sakura(self, sakura: Sakura):
         src = self.sakura_download_src
+        gguf_path = SETTING.gguf_path.strip()
+        if not gguf_path:
+            gguf_path = CURRENT_DIR
         task = DownloadTask(
             name="Sakura模型",
             url=sakura.download_links[src],
             filename=sakura.filename,
+            filepath=gguf_path,
         )
 
         def on_download_sakura_finish():
-            file_path = os.path.join(CURRENT_DIR, task.filename)
+            file_path = os.path.join(gguf_path, task.filename)
             if sakura.check_sha256(file_path):
                 task.state = DownloadTaskState.SUCCESS
                 UiInfoBarSuccess(self, f"{task.name}下载成功")

--- a/src/section_run_server.py
+++ b/src/section_run_server.py
@@ -191,7 +191,8 @@ class RunServerSection(QFrame):
         self.model_path.clear()
         models = []
         paths = SETTING.model_search_paths.split("\n")
-        search_paths = [CURRENT_DIR] + [path.strip() for path in paths if path.strip()]
+        gguf_path = SETTING.gguf_path.strip()
+        search_paths = [CURRENT_DIR, gguf_path] + [path.strip() for path in paths if path.strip()]
         logging.debug(f"搜索路径: {search_paths}")
         for path in search_paths:
             logging.debug(f"正在搜索路径: {path}")

--- a/src/section_settings.py
+++ b/src/section_settings.py
@@ -221,6 +221,10 @@ class SettingsSection(QFrame):
         llamacpp_path.textChanged.connect(
             lambda text: SETTING.set_value("llamacpp_path", text)
         )
+        gguf_path = UiLineEdit("可选，手动指定Sakura模型下载路径", SETTING.gguf_path)
+        gguf_path.textChanged.connect(
+            lambda text: SETTING.set_value("gguf_path", text)
+        )
         model_search_paths = TextEdit()
         model_search_paths.setPlaceholderText(
             "模型搜索路径（每行一个路径，已经默认包含当前目录）"
@@ -240,6 +244,7 @@ class SettingsSection(QFrame):
             no_context_check,
             UiOptionRow("模型列表排序", model_sort_combo),
             UiOptionRow("llama.cpp文件夹", llamacpp_path),
+            UiOptionRow("Sakura模型文件夹", gguf_path),
             UiOptionCol("模型搜索路径", model_search_paths),
         )
 

--- a/src/section_settings.py
+++ b/src/section_settings.py
@@ -221,7 +221,7 @@ class SettingsSection(QFrame):
         llamacpp_path.textChanged.connect(
             lambda text: SETTING.set_value("llamacpp_path", text)
         )
-        gguf_path = UiLineEdit("可选，手动指定Sakura模型下载路径", SETTING.gguf_path)
+        gguf_path = UiLineEdit("可选，手动指定Sakura模型下载路径，默认为启动器所在的文件夹", SETTING.gguf_path)
         gguf_path.textChanged.connect(
             lambda text: SETTING.set_value("gguf_path", text)
         )

--- a/src/setting.py
+++ b/src/setting.py
@@ -21,6 +21,7 @@ class Setting(QObject):
 
     # 各个属性的专用信号
     llamacpp_path_changed = Signal(str)
+    gguf_path_changed = Signal(str)
     model_search_paths_changed = Signal(str)
     model_sort_option_changed = Signal(str)
     remember_window_state_changed = Signal(bool)
@@ -41,6 +42,7 @@ class Setting(QObject):
 
         for sig in [
             self.llamacpp_path_changed,
+            self.gguf_path_changed,
             self.model_search_paths_changed,
             self.model_sort_option_changed,
             self.remember_window_state_changed,
@@ -91,6 +93,7 @@ class Setting(QObject):
     def save_settings(self):
         settings = {
             "llamacpp_path": self.llamacpp_path,
+            "gguf_path": self.gguf_path,
             "model_search_paths": self.model_search_paths,
             "model_sort_option": self.model_sort_option,
             "remember_window_state": self.remember_window_state,
@@ -111,6 +114,7 @@ class Setting(QObject):
     def _load_settings(self):
         settings = self._read_settings()
         self.llamacpp_path = settings.get("llamacpp_path", "")
+        self.gguf_path = settings.get("gguf_path", "")
         self.model_search_paths = settings.get("model_search_paths", "")
         self.model_sort_option = settings.get("model_sort_option", "修改时间")
         self.remember_window_state = settings.get("remember_window_state", False)


### PR DESCRIPTION
对 #60 的粗浅实现，仅实现了自定义sakura模型下载路径的功能

<img width="900" height="1050" alt="image" src="https://github.com/user-attachments/assets/cf33c9a8-59ba-4738-9041-94c18b6a5b71" />

<img width="2425" height="145" alt="image" src="https://github.com/user-attachments/assets/689f7cd5-c0e2-4759-a523-00321d3f0914" />
